### PR TITLE
Switch Hash param to T::Hash[Symbol, T.untyped]

### DIFF
--- a/main.go
+++ b/main.go
@@ -310,7 +310,7 @@ module {{ rubyPackage .File }}::{{ .Name }}
       params(
         host: String,
         creds: T.any(GRPC::Core::ChannelCredentials, Symbol),
-        kw: Hash
+        kw: T::Hash[Symbol, T.untyped]
       ).void
     end
     def initialize(host, creds, **kw)

--- a/testdata/example_services_pb.rbi
+++ b/testdata/example_services_pb.rbi
@@ -12,7 +12,7 @@ module Example::Greeter
       params(
         host: String,
         creds: T.any(GRPC::Core::ChannelCredentials, Symbol),
-        kw: Hash
+        kw: T::Hash[Symbol, T.untyped]
       ).void
     end
     def initialize(host, creds, **kw)

--- a/testdata/services_services_pb.rbi
+++ b/testdata/services_services_pb.rbi
@@ -12,7 +12,7 @@ module Testdata::SimpleMathematics
       params(
         host: String,
         creds: T.any(GRPC::Core::ChannelCredentials, Symbol),
-        kw: Hash
+        kw: T::Hash[Symbol, T.untyped]
       ).void
     end
     def initialize(host, creds, **kw)
@@ -46,7 +46,7 @@ module Testdata::ComplexMathematics
       params(
         host: String,
         creds: T.any(GRPC::Core::ChannelCredentials, Symbol),
-        kw: Hash
+        kw: T::Hash[Symbol, T.untyped]
       ).void
     end
     def initialize(host, creds, **kw)


### PR DESCRIPTION
Sorbet doesn't like untyped `Hash` argument types (`Malformed type declaration. Generic class without type arguments Hash https://srb.help/5046`)... switch to `T::Hash[Symbol, T.untyped]`