### PR TITLE
Allow enum setters to receive Integers and Symbols

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,30 +1,15 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"strings"
 	"text/template"
 
+	"github.com/coinbase/protoc-gen-rbi/ruby_types"
+
 	pgs "github.com/lyft/protoc-gen-star"
 	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
 )
-
-// intersection between pgs.FieldType and pgs.FieldTypeElem
-type FieldType interface {
-	ProtoType() pgs.ProtoType
-	IsEmbed() bool
-	IsEnum() bool
-	Imports() []pgs.File
-	Enum() pgs.Enum
-	Embed() pgs.Message
-}
-
-// intersection between pgs.Message and pgs.Enum
-type EntityWithParent interface {
-	pgs.Entity
-	Parent() pgs.ParentEntity
-}
 
 type rbiModule struct {
 	*pgs.ModuleBase
@@ -40,13 +25,16 @@ func (m *rbiModule) InitContext(c pgs.BuildContext) {
 	m.ctx = pgsgo.InitContext(c.Parameters())
 
 	funcs := map[string]interface{}{
-		"modules": m.modules,
-		"rubyPackage": m.rubyPackage,
-		"rubyMessageType": m.rubyMessageType,
-		"rubyFieldType": m.rubyFieldType,
-		"rubyFieldValue": m.rubyFieldValue,
-		"rubyMethodType": m.rubyMethodType,
 		"increment": m.increment,
+		"rubyModules": ruby_types.RubyModules,
+		"rubyPackage": ruby_types.RubyPackage,
+		"rubyMessageType": ruby_types.RubyMessageType,
+		"rubyGetterFieldType": ruby_types.RubyGetterFieldType,
+		"rubySetterFieldType": ruby_types.RubySetterFieldType,
+		"rubyInitializerFieldType": ruby_types.RubyInitializerFieldType,
+		"rubyFieldValue": ruby_types.RubyFieldValue,
+		"rubyMethodParamType": ruby_types.RubyMethodParamType,
+		"rubyMethodReturnType": ruby_types.RubyMethodReturnType,
 	}
 
 	m.tpl = template.Must(template.New("rbi").Funcs(funcs).Parse(tpl))
@@ -81,173 +69,6 @@ func (m *rbiModule) generateServices(f pgs.File) {
 	m.AddGeneratorTemplateFile(op, m.serviceTpl, f)
 }
 
-func (m *rbiModule) modules(file pgs.File) []string {
-	p := m.rubyPackage(file)
-	split := strings.Split(p, "::")
-	modules := make([]string, 0)
-	for i := 0; i < len(split); i++ {
-		modules = append(modules, strings.Join(split[0:i+1], "::"))
-	}
-	return modules
-}
-
-func (m *rbiModule) rubyPackage(file pgs.File) string {
-	pkg := file.Descriptor().GetOptions().GetRubyPackage()
-	if pkg == "" {
-		pkg = file.Descriptor().GetPackage()
-	}
-	pkg = strings.Replace(pkg, ".", "::", -1)
-	// right now the ruby_out doesn't camelcase the ruby_package, but this results in invalid classes, so do it:
-	return pgs.Name(pkg).UpperCamelCase().String()
-}
-
-func (m *rbiModule) rubyMessageType(entity EntityWithParent) string {
-	names := make([]string, 0)
-	outer := entity
-	ok := true
-	for ok {
-		names = append([]string{outer.Name().String()}, names...)
-		outer, ok = outer.Parent().(pgs.Message)
-	}
-	return fmt.Sprintf("%s::%s", m.rubyPackage(entity.File()), strings.Join(names, "::"))
-}
-
-func (m *rbiModule) rubyFieldType(field pgs.Field, setter bool) string {
-	t := field.Type()
-	if t.IsMap() {
-		if setter {
-			return "Google::Protobuf::Map"
-		}
-		key := m.rubyProtoTypeElem(field, t.Key())
-		value := m.rubyProtoTypeElem(field, t.Element())
-		return fmt.Sprintf("T::Hash[%s, %s]", key, value)
-	} else if t.IsRepeated() {
-		value := m.rubyProtoTypeElem(field, t.Element())
-		return fmt.Sprintf("T::Array[%s]", value)
-	}
-	return m.rubyProtoTypeElem(field, t)
-}
-
-func (m *rbiModule) rubyFieldValue(field pgs.Field) string {
-	t := field.Type()
-	if t.IsMap() {
-		key := m.rubyMapType(t.Key())
-		if t.Element().ProtoType() == pgs.MessageT {
-			value := m.rubyMessageType(t.Element().Embed())
-			return fmt.Sprintf("Google::Protobuf::Map.new(%s, :message, %s)", key, value)
-		}
-		value := m.rubyMapType(t.Element())
-		return fmt.Sprintf("Google::Protobuf::Map.new(%s, %s)", key, value)
-	} else if t.IsRepeated() {
-		return "[]"
-	}
-	return m.rubyProtoTypeValue(field, t)
-}
-
-func (m *rbiModule) rubyProtoTypeElem(field pgs.Field, ft FieldType) string {
-	pt := ft.ProtoType()
-	if pt.IsInt() {
-		return "Integer"
-	}
-	if pt.IsNumeric() {
-		return "Float"
-	}
-	if pt == pgs.StringT || pt == pgs.BytesT {
-		return "String"
-	}
-	if pt == pgs.BoolT {
-		return "T::Boolean"
-	}
-	if pt == pgs.EnumT {
-		return "Symbol"
-	}
-	if pt == pgs.MessageT {
-		return fmt.Sprintf("T.nilable(%s)", m.rubyMessageType(ft.Embed()))
-	}
-	log.Panicf("Unsupported field type for field: %v\n", field.Name().String())
-	return ""
-}
-
-func (m *rbiModule) rubyProtoTypeValue(field pgs.Field, ft FieldType) string {
-	pt := ft.ProtoType()
-	if pt.IsInt() {
-		return "0"
-	}
-	if pt.IsNumeric() {
-		return "0.0"
-	}
-	if pt == pgs.StringT || pt == pgs.BytesT {
-		return "\"\""
-	}
-	if pt == pgs.BoolT {
-		return "false"
-	}
-	if pt == pgs.EnumT {
-		return fmt.Sprintf(":%s", ft.Enum().Values()[0].Name().String())
-	}
-	if pt == pgs.MessageT {
-		return "nil"
-	}
-	log.Panicf("Unsupported field type for field: %v\n", field.Name().String())
-	return ""
-}
-
-func (m *rbiModule) rubyMapType(ft FieldType) string {
-	switch ft.ProtoType() {
-	case pgs.DoubleT:
-		return ":double"
-	case pgs.FloatT:
-		return ":float"
-	case pgs.Int64T:
-		return ":int64"
-	case pgs.UInt64T:
-		return ":uint64"
-	case pgs.Int32T:
-		return ":int32"
-	case pgs.Fixed64T:
-		return ":fixed64"
-	case pgs.Fixed32T:
-		return ":fixed32"
-	case pgs.BoolT:
-		return ":bool"
-	case pgs.StringT:
-		return ":string"
-	case pgs.BytesT:
-		return ":bytes"
-	case pgs.UInt32T:
-		return ":uint32"
-	case pgs.EnumT:
-		return ":enum"
-	case pgs.SFixed32:
-		return ":sfixed32"
-	case pgs.SFixed64:
-		return ":sfixed64"
-	case pgs.SInt32:
-		return ":sint32"
-	case pgs.SInt64:
-		return ":sint64"
-	}
-	log.Panicf("Unsupported map field type\n")
-	return ""
-}
-
-func (m *rbiModule) rubyMethodType(method pgs.Method, input bool) string {
-	var streaming bool
-	var message pgs.Message
-	if input {
-		streaming = method.ClientStreaming()
-		message = method.Input()
-	} else {
-		streaming = method.ServerStreaming()
-		message = method.Output()
-	}
-	t := m.rubyMessageType(message)
-	if streaming {
-		return fmt.Sprintf("T::Enumerable[%s]", t)
-	}
-	return t
-}
-
 func (m *rbiModule) increment(i int) int {
 	return i + 1
 }
@@ -265,7 +86,7 @@ func main() {
 const tpl = `# Code generated by protoc-gen-rbi. DO NOT EDIT.
 # source: {{ .InputPath }}
 # typed: strict
-{{ range modules . }}
+{{ range rubyModules . }}
 module {{ . }}; end{{ end }}
 {{ range .AllMessages }}
 class {{ rubyMessageType . }}
@@ -274,7 +95,7 @@ class {{ rubyMessageType . }}
 {{ if gt (len .Fields) 0 }}
   sig do
     params({{ $index := 0 }}{{ range .Fields }}{{ if gt $index 0 }},{{ end }}{{ $index = increment $index }}
-      {{ .Name }}: {{ rubyFieldType . true }}{{ end }}
+      {{ .Name }}: {{ rubyInitializerFieldType . }}{{ end }}
     ).void
   end
   def initialize({{ $index := 0 }}{{ range .Fields }}{{ if gt $index 0 }},{{ end }}{{ $index = increment $index }}
@@ -282,17 +103,21 @@ class {{ rubyMessageType . }}
   )
   end
 {{ end }}{{ range .Fields }}
-  sig { returns({{ rubyFieldType . false }}) }
+  sig { returns({{ rubyGetterFieldType . }}) }
   def {{ .Name }}
   end
 
-  sig { params(value: {{ rubyFieldType . true }}).void }
+  sig { params(value: {{ rubySetterFieldType . }}).void }
   def {{ .Name }}=(value)
   end
 {{ end }}end
 {{ end }}{{ range .AllEnums }}
 module {{ rubyMessageType . }}{{ range .Values }}
   {{ .Name }} = T.let({{ .Value }}, Integer){{ end }}
+
+  sig { params(value: Integer).returns(Symbol) }
+  def lookup(value)
+  end
 end
 {{ end }}`
 
@@ -318,8 +143,8 @@ module {{ rubyPackage .File }}::{{ .Name }}
 
     sig do
       params(
-        request: {{ rubyMethodType . true }}
-      ).returns({{ rubyMethodType . false }})
+        request: {{ rubyMethodParamType . }}
+      ).returns({{ rubyMethodReturnType . }})
     end
     def {{ .Name.LowerSnakeCase }}(request)
     end{{ end }}

--- a/ruby_types/ruby_types.go
+++ b/ruby_types/ruby_types.go
@@ -1,0 +1,212 @@
+package ruby_types
+
+import (
+	"fmt"
+	pgs "github.com/lyft/protoc-gen-star"
+	"log"
+	"strings"
+)
+
+type methodType int
+const (
+	methodTypeGetter methodType = iota
+	methodTypeSetter
+	methodTypeInitializer
+)
+
+// intersection between pgs.FieldType and pgs.FieldTypeElem
+type FieldType interface {
+	ProtoType() pgs.ProtoType
+	IsEmbed() bool
+	IsEnum() bool
+	Imports() []pgs.File
+	Enum() pgs.Enum
+	Embed() pgs.Message
+}
+
+// intersection between pgs.Message and pgs.Enum
+type EntityWithParent interface {
+	pgs.Entity
+	Parent() pgs.ParentEntity
+}
+
+func RubyModules(file pgs.File) []string {
+	p := RubyPackage(file)
+	split := strings.Split(p, "::")
+	modules := make([]string, 0)
+	for i := 0; i < len(split); i++ {
+		modules = append(modules, strings.Join(split[0:i+1], "::"))
+	}
+	return modules
+}
+
+func RubyPackage(file pgs.File) string {
+	pkg := file.Descriptor().GetOptions().GetRubyPackage()
+	if pkg == "" {
+		pkg = file.Descriptor().GetPackage()
+	}
+	pkg = strings.Replace(pkg, ".", "::", -1)
+	// right now the ruby_out doesn't camelcase the ruby_package, but this results in invalid classes, so do it:
+	return pgs.Name(pkg).UpperCamelCase().String()
+}
+
+func RubyMessageType(entity EntityWithParent) string {
+	names := make([]string, 0)
+	outer := entity
+	ok := true
+	for ok {
+		names = append([]string{outer.Name().String()}, names...)
+		outer, ok = outer.Parent().(pgs.Message)
+	}
+	return fmt.Sprintf("%s::%s", RubyPackage(entity.File()), strings.Join(names, "::"))
+}
+
+func RubyGetterFieldType(field pgs.Field) string {
+	return rubyFieldType(field, methodTypeGetter)
+}
+
+func RubySetterFieldType(field pgs.Field) string {
+	return rubyFieldType(field, methodTypeSetter)
+}
+
+func RubyInitializerFieldType(field pgs.Field) string {
+	return rubyFieldType(field, methodTypeInitializer)
+}
+
+func rubyFieldType(field pgs.Field, mt methodType) string {
+	t := field.Type()
+	if t.IsMap() {
+		if mt == methodTypeSetter {
+			return "Google::Protobuf::Map"
+		}
+		key := rubyProtoTypeElem(field, t.Key(), mt)
+		value := rubyProtoTypeElem(field, t.Element(), mt)
+		return fmt.Sprintf("T::Hash[%s, %s]", key, value)
+	} else if t.IsRepeated() {
+		value := rubyProtoTypeElem(field, t.Element(), mt)
+		return fmt.Sprintf("T::Array[%s]", value)
+	}
+	return rubyProtoTypeElem(field, t, mt)
+}
+
+func RubyFieldValue(field pgs.Field) string {
+	t := field.Type()
+	if t.IsMap() {
+		key := rubyMapType(t.Key())
+		if t.Element().ProtoType() == pgs.MessageT {
+			value := RubyMessageType(t.Element().Embed())
+			return fmt.Sprintf("Google::Protobuf::Map.new(%s, :message, %s)", key, value)
+		}
+		value := rubyMapType(t.Element())
+		return fmt.Sprintf("Google::Protobuf::Map.new(%s, %s)", key, value)
+	} else if t.IsRepeated() {
+		return "[]"
+	}
+	return rubyProtoTypeValue(field, t)
+}
+
+func rubyProtoTypeElem(field pgs.Field, ft FieldType, mt methodType) string {
+	pt := ft.ProtoType()
+	if pt.IsInt() {
+		return "Integer"
+	}
+	if pt.IsNumeric() {
+		return "Float"
+	}
+	if pt == pgs.StringT || pt == pgs.BytesT {
+		return "String"
+	}
+	if pt == pgs.BoolT {
+		return "T::Boolean"
+	}
+	if pt == pgs.EnumT {
+		if mt == methodTypeGetter {
+			return "Symbol"
+		}
+		return "T.any(Symbol, Integer)"
+	}
+	if pt == pgs.MessageT {
+		return fmt.Sprintf("T.nilable(%s)", RubyMessageType(ft.Embed()))
+	}
+	log.Panicf("Unsupported field type for field: %v\n", field.Name().String())
+	return ""
+}
+
+func rubyProtoTypeValue(field pgs.Field, ft FieldType) string {
+	pt := ft.ProtoType()
+	if pt.IsInt() {
+		return "0"
+	}
+	if pt.IsNumeric() {
+		return "0.0"
+	}
+	if pt == pgs.StringT || pt == pgs.BytesT {
+		return "\"\""
+	}
+	if pt == pgs.BoolT {
+		return "false"
+	}
+	if pt == pgs.EnumT {
+		return fmt.Sprintf(":%s", ft.Enum().Values()[0].Name().String())
+	}
+	if pt == pgs.MessageT {
+		return "nil"
+	}
+	log.Panicf("Unsupported field type for field: %v\n", field.Name().String())
+	return ""
+}
+
+func rubyMapType(ft FieldType) string {
+	switch ft.ProtoType() {
+	case pgs.DoubleT:
+		return ":double"
+	case pgs.FloatT:
+		return ":float"
+	case pgs.Int64T:
+		return ":int64"
+	case pgs.UInt64T:
+		return ":uint64"
+	case pgs.Int32T:
+		return ":int32"
+	case pgs.Fixed64T:
+		return ":fixed64"
+	case pgs.Fixed32T:
+		return ":fixed32"
+	case pgs.BoolT:
+		return ":bool"
+	case pgs.StringT:
+		return ":string"
+	case pgs.BytesT:
+		return ":bytes"
+	case pgs.UInt32T:
+		return ":uint32"
+	case pgs.EnumT:
+		return ":enum"
+	case pgs.SFixed32:
+		return ":sfixed32"
+	case pgs.SFixed64:
+		return ":sfixed64"
+	case pgs.SInt32:
+		return ":sint32"
+	case pgs.SInt64:
+		return ":sint64"
+	}
+	log.Panicf("Unsupported map field type\n")
+	return ""
+}
+
+func RubyMethodParamType(method pgs.Method) string {
+	return rubyMethodType(method.Input(), method.ClientStreaming())
+}
+
+func RubyMethodReturnType(method pgs.Method) string {
+	return rubyMethodType(method.Output(), method.ServerStreaming())
+}
+
+func rubyMethodType(message pgs.Message, streaming bool) string {
+	t := RubyMessageType(message)
+	if streaming {
+		return fmt.Sprintf("T::Enumerable[%s]", t)
+	}
+	return t
+}

--- a/testdata/subdir/messages.proto
+++ b/testdata/subdir/messages.proto
@@ -55,19 +55,21 @@ message AllTypes {
   IntegerMessage nested_value = 18;
   repeated IntegerMessage repeated_nested_value = 19;
   repeated int32 repeated_int32_value = 20;
+  repeated Corpus repeated_enum = 21;
 
   message InnerMessage {
     string value = 1;
   }
-  InnerMessage inner_value = 21;
+  InnerMessage inner_value = 22;
 
-  IntegerMessage.InnerNestedMessage inner_nested_value = 22;
+  IntegerMessage.InnerNestedMessage inner_nested_value = 23;
 
   oneof test_oneof {
-    string name = 23;
-    bool sub_message = 24;
+    string name = 24;
+    bool sub_message = 25;
   }
 
-  map<string, IntegerMessage> string_map_value = 25;
-  map<int32, IntegerMessage> int32_map_value = 26;
+  map<string, IntegerMessage> string_map_value = 26;
+  map<int32, IntegerMessage> int32_map_value = 27;
+  map<string, Corpus> enum_map_value = 28;
 }

--- a/testdata/subdir/messages_pb.rb
+++ b/testdata/subdir/messages_pb.rb
@@ -36,13 +36,15 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :nested_value, :message, 18, "testdata.subdir.IntegerMessage"
       repeated :repeated_nested_value, :message, 19, "testdata.subdir.IntegerMessage"
       repeated :repeated_int32_value, :int32, 20
-      optional :inner_value, :message, 21, "testdata.subdir.AllTypes.InnerMessage"
-      optional :inner_nested_value, :message, 22, "testdata.subdir.IntegerMessage.InnerNestedMessage"
-      map :string_map_value, :string, :message, 25, "testdata.subdir.IntegerMessage"
-      map :int32_map_value, :int32, :message, 26, "testdata.subdir.IntegerMessage"
+      repeated :repeated_enum, :enum, 21, "testdata.subdir.AllTypes.Corpus"
+      optional :inner_value, :message, 22, "testdata.subdir.AllTypes.InnerMessage"
+      optional :inner_nested_value, :message, 23, "testdata.subdir.IntegerMessage.InnerNestedMessage"
+      map :string_map_value, :string, :message, 26, "testdata.subdir.IntegerMessage"
+      map :int32_map_value, :int32, :message, 27, "testdata.subdir.IntegerMessage"
+      map :enum_map_value, :string, :enum, 28, "testdata.subdir.AllTypes.Corpus"
       oneof :test_oneof do
-        optional :name, :string, 23
-        optional :sub_message, :bool, 24
+        optional :name, :string, 24
+        optional :sub_message, :bool, 25
       end
     end
     add_message "testdata.subdir.AllTypes.InnerMessage" do

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -54,17 +54,19 @@ class Testdata::Subdir::AllTypes
       bool_value: T::Boolean,
       string_value: String,
       bytes_value: String,
-      enum_value: Symbol,
-      alias_enum_value: Symbol,
+      enum_value: T.any(Symbol, Integer),
+      alias_enum_value: T.any(Symbol, Integer),
       nested_value: T.nilable(Testdata::Subdir::IntegerMessage),
       repeated_nested_value: T::Array[T.nilable(Testdata::Subdir::IntegerMessage)],
       repeated_int32_value: T::Array[Integer],
+      repeated_enum: T::Array[T.any(Symbol, Integer)],
       inner_value: T.nilable(Testdata::Subdir::AllTypes::InnerMessage),
       inner_nested_value: T.nilable(Testdata::Subdir::IntegerMessage::InnerNestedMessage),
       name: String,
       sub_message: T::Boolean,
-      string_map_value: Google::Protobuf::Map,
-      int32_map_value: Google::Protobuf::Map
+      string_map_value: T::Hash[String, T.nilable(Testdata::Subdir::IntegerMessage)],
+      int32_map_value: T::Hash[Integer, T.nilable(Testdata::Subdir::IntegerMessage)],
+      enum_map_value: T::Hash[String, T.any(Symbol, Integer)]
     ).void
   end
   def initialize(
@@ -88,12 +90,14 @@ class Testdata::Subdir::AllTypes
     nested_value: nil,
     repeated_nested_value: [],
     repeated_int32_value: [],
+    repeated_enum: [],
     inner_value: nil,
     inner_nested_value: nil,
     name: "",
     sub_message: false,
     string_map_value: Google::Protobuf::Map.new(:string, :message, Testdata::Subdir::IntegerMessage),
-    int32_map_value: Google::Protobuf::Map.new(:int32, :message, Testdata::Subdir::IntegerMessage)
+    int32_map_value: Google::Protobuf::Map.new(:int32, :message, Testdata::Subdir::IntegerMessage),
+    enum_map_value: Google::Protobuf::Map.new(:string, :enum)
   )
   end
 
@@ -221,7 +225,7 @@ class Testdata::Subdir::AllTypes
   def enum_value
   end
 
-  sig { params(value: Symbol).void }
+  sig { params(value: T.any(Symbol, Integer)).void }
   def enum_value=(value)
   end
 
@@ -229,7 +233,7 @@ class Testdata::Subdir::AllTypes
   def alias_enum_value
   end
 
-  sig { params(value: Symbol).void }
+  sig { params(value: T.any(Symbol, Integer)).void }
   def alias_enum_value=(value)
   end
 
@@ -255,6 +259,14 @@ class Testdata::Subdir::AllTypes
 
   sig { params(value: T::Array[Integer]).void }
   def repeated_int32_value=(value)
+  end
+
+  sig { returns(T::Array[Symbol]) }
+  def repeated_enum
+  end
+
+  sig { params(value: T::Array[T.any(Symbol, Integer)]).void }
+  def repeated_enum=(value)
   end
 
   sig { returns(T.nilable(Testdata::Subdir::AllTypes::InnerMessage)) }
@@ -303,6 +315,14 @@ class Testdata::Subdir::AllTypes
 
   sig { params(value: Google::Protobuf::Map).void }
   def int32_map_value=(value)
+  end
+
+  sig { returns(T::Hash[String, Symbol]) }
+  def enum_map_value
+  end
+
+  sig { params(value: Google::Protobuf::Map).void }
+  def enum_map_value=(value)
   end
 end
 
@@ -365,10 +385,18 @@ module Testdata::Subdir::AllTypes::Corpus
   NEWS = T.let(4, Integer)
   PRODUCTS = T.let(5, Integer)
   VIDEO = T.let(6, Integer)
+
+  sig { params(value: Integer).returns(Symbol) }
+  def lookup(value)
+  end
 end
 
 module Testdata::Subdir::AllTypes::EnumAllowingAlias
   UNKNOWN = T.let(0, Integer)
   STARTED = T.let(1, Integer)
   RUNNING = T.let(1, Integer)
+
+  sig { params(value: Integer).returns(Symbol) }
+  def lookup(value)
+  end
 end


### PR DESCRIPTION
Ruby protobuf objects support both `Integer` and `Symbol` parameters to enum initializer fields and enum field setters. This PR switches the setter `sig` on enum fields from
```ruby
sig { params(value: Symbol).void }
```
to
```ruby
sig { params(value: T.any(Symbol, Integer)).void }
```

Protobuf initializers also support passing a hash to map fields, so switched the initializer from fields taking a `Google::Protobuf::Map` to a `T::Hash[]`. Unfortunately the setters don't support the same.

There's also a `lookup` method that is available on generated enum modules that has been added to the `.rbi` file.

It also moves some common Ruby type handling to a separate package so it can be shared.