### PR TITLE
Mark enum module `lookup` as a class method

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ module {{ rubyMessageType . }}{{ range .Values }}
   {{ .Name }} = T.let({{ .Value }}, Integer){{ end }}
 
   sig { params(value: Integer).returns(Symbol) }
-  def lookup(value)
+  def self.lookup(value)
   end
 end
 {{ end }}`

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -387,7 +387,7 @@ module Testdata::Subdir::AllTypes::Corpus
   VIDEO = T.let(6, Integer)
 
   sig { params(value: Integer).returns(Symbol) }
-  def lookup(value)
+  def self.lookup(value)
   end
 end
 
@@ -397,6 +397,6 @@ module Testdata::Subdir::AllTypes::EnumAllowingAlias
   RUNNING = T.let(1, Integer)
 
   sig { params(value: Integer).returns(Symbol) }
-  def lookup(value)
+  def self.lookup(value)
   end
 end


### PR DESCRIPTION
#4 introduced the `lookup` method on generated enum modules. It should have been marked as a `self` class method; this PR fixes that.