### PR TITLE
Fix keyword argument types

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ module {{ rubyPackage .File }}::{{ .Name }}
       params(
         host: String,
         creds: T.any(GRPC::Core::ChannelCredentials, Symbol),
-        kw: T::Hash[Symbol, T.untyped]
+        kw: T.untyped,
       ).void
     end
     def initialize(host, creds, **kw)

--- a/testdata/example_services_pb.rbi
+++ b/testdata/example_services_pb.rbi
@@ -12,7 +12,7 @@ module Example::Greeter
       params(
         host: String,
         creds: T.any(GRPC::Core::ChannelCredentials, Symbol),
-        kw: T::Hash[Symbol, T.untyped]
+        kw: T.untyped,
       ).void
     end
     def initialize(host, creds, **kw)

--- a/testdata/services_services_pb.rbi
+++ b/testdata/services_services_pb.rbi
@@ -12,7 +12,7 @@ module Testdata::SimpleMathematics
       params(
         host: String,
         creds: T.any(GRPC::Core::ChannelCredentials, Symbol),
-        kw: T::Hash[Symbol, T.untyped]
+        kw: T.untyped,
       ).void
     end
     def initialize(host, creds, **kw)
@@ -46,7 +46,7 @@ module Testdata::ComplexMathematics
       params(
         host: String,
         creds: T.any(GRPC::Core::ChannelCredentials, Symbol),
-        kw: T::Hash[Symbol, T.untyped]
+        kw: T.untyped,
       ).void
     end
     def initialize(host, creds, **kw)


### PR DESCRIPTION
The current `sig` for the splatted `kws` argument is wrong. The type is declared as `T::Hash[Symbol, T.untyped]` in the sig, but that's meant to refer to the type of one of the named arguments that makes up `kws`, not the type of `kws` itself. See [an example of this in the Sorbet playground](https://sorbet.run/#%23%20typed%3A%20strict%0Aextend%20T%3A%3ASig%0A%0Asig%20%7Bparams(x%3A%20Integer).void%7D%0Adef%20foo(**x)%0A%20%20T.assert_type!(x%2C%20T%3A%3AHash%5BSymbol%2C%20Integer%5D)%0Aend%0A%0Asig%20%7Bparams(x%3A%20T%3A%3AHash%5BSymbol%2C%20Integer%5D).void%7D%0Adef%20bar(**x)%0A%20%20T.assert_type!(x%2C%20T%3A%3AHash%5BSymbol%2C%20T%3A%3AHash%5BSymbol%2C%20Integer%5D%5D)%0Aend).

Declaring the type this way causes Sorbet to complain unless the keyword argument being passed in just happens to be a Hash already. This PR changes the typing of `kws` from:

```
T.assert_type!(kws, T::Hash[Symbol, T::Hash[Symbol, Integer]])
```

to

```
T.assert_type!(kws, T::Hash[Symbol, Integer])
```

cc @idiamond-stripe