### PR TITLE
Mark stubs as subclassing GRPC::ClientStub

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ module {{ rubyPackage .File }}::{{ .Name }}
     include GRPC::GenericService
   end
 
-  class Stub
+  class Stub < GRPC::ClientStub
     sig do
       params(
         host: String,

--- a/testdata/example_services_pb.rbi
+++ b/testdata/example_services_pb.rbi
@@ -7,7 +7,7 @@ module Example::Greeter
     include GRPC::GenericService
   end
 
-  class Stub
+  class Stub < GRPC::ClientStub
     sig do
       params(
         host: String,

--- a/testdata/services_services_pb.rbi
+++ b/testdata/services_services_pb.rbi
@@ -7,7 +7,7 @@ module Testdata::SimpleMathematics
     include GRPC::GenericService
   end
 
-  class Stub
+  class Stub < GRPC::ClientStub
     sig do
       params(
         host: String,
@@ -41,7 +41,7 @@ module Testdata::ComplexMathematics
     include GRPC::GenericService
   end
 
-  class Stub
+  class Stub < GRPC::ClientStub
     sig do
       params(
         host: String,


### PR DESCRIPTION
This makes it possible to typecheck methods which operate generically on any GRCP::ClientStub.

eg: Sorbet can now assert that `T.assert_type!(Example::Greeter::Stub, T.class_of(GRPC::ClientStub))`

cc @idiamond-stripe