### PR TITLE
Allow specifying Enums as Strings

### DIFF
--- a/ruby_types/ruby_types.go
+++ b/ruby_types/ruby_types.go
@@ -123,7 +123,7 @@ func rubyProtoTypeElem(field pgs.Field, ft FieldType, mt methodType) string {
 		if mt == methodTypeGetter {
 			return "Symbol"
 		}
-		return "T.any(Symbol, Integer)"
+		return "T.any(Symbol, String, Integer)"
 	}
 	if pt == pgs.MessageT {
 		return fmt.Sprintf("T.nilable(%s)", RubyMessageType(ft.Embed()))

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -54,19 +54,19 @@ class Testdata::Subdir::AllTypes
       bool_value: T::Boolean,
       string_value: String,
       bytes_value: String,
-      enum_value: T.any(Symbol, Integer),
-      alias_enum_value: T.any(Symbol, Integer),
+      enum_value: T.any(Symbol, String, Integer),
+      alias_enum_value: T.any(Symbol, String, Integer),
       nested_value: T.nilable(Testdata::Subdir::IntegerMessage),
       repeated_nested_value: T::Array[T.nilable(Testdata::Subdir::IntegerMessage)],
       repeated_int32_value: T::Array[Integer],
-      repeated_enum: T::Array[T.any(Symbol, Integer)],
+      repeated_enum: T::Array[T.any(Symbol, String, Integer)],
       inner_value: T.nilable(Testdata::Subdir::AllTypes::InnerMessage),
       inner_nested_value: T.nilable(Testdata::Subdir::IntegerMessage::InnerNestedMessage),
       name: String,
       sub_message: T::Boolean,
       string_map_value: T::Hash[String, T.nilable(Testdata::Subdir::IntegerMessage)],
       int32_map_value: T::Hash[Integer, T.nilable(Testdata::Subdir::IntegerMessage)],
-      enum_map_value: T::Hash[String, T.any(Symbol, Integer)]
+      enum_map_value: T::Hash[String, T.any(Symbol, String, Integer)]
     ).void
   end
   def initialize(
@@ -225,7 +225,7 @@ class Testdata::Subdir::AllTypes
   def enum_value
   end
 
-  sig { params(value: T.any(Symbol, Integer)).void }
+  sig { params(value: T.any(Symbol, String, Integer)).void }
   def enum_value=(value)
   end
 
@@ -233,7 +233,7 @@ class Testdata::Subdir::AllTypes
   def alias_enum_value
   end
 
-  sig { params(value: T.any(Symbol, Integer)).void }
+  sig { params(value: T.any(Symbol, String, Integer)).void }
   def alias_enum_value=(value)
   end
 
@@ -265,7 +265,7 @@ class Testdata::Subdir::AllTypes
   def repeated_enum
   end
 
-  sig { params(value: T::Array[T.any(Symbol, Integer)]).void }
+  sig { params(value: T::Array[T.any(Symbol, String, Integer)]).void }
   def repeated_enum=(value)
   end
 


### PR DESCRIPTION
It turns out that Ruby protobuf objects allow setting enums to an Integer, Symbol _or_ String value - this makes the generated `sig`s surface that properly.

(This is a minor tweak to https://github.com/coinbase/protoc-gen-rbi/pull/4, which added Symbol support.)

cc @idiamond-stripe