### PR TITLE
add a few missing methods

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,6 +107,22 @@ module {{ . }}; end{{ end }}
 class {{ rubyMessageType . }}
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+
+  sig { params(str: String).returns({{ rubyMessageType . }}) }
+  def self.decode(str)
+  end
+
+  sig { params(msg: {{ rubyMessageType . }}).returns(String) }
+  def self.encode(msg)
+  end
+
+  sig { params(str: String).returns({{ rubyMessageType . }}) }
+  def self.decode_json(str)
+  end
+
+  sig { params(msg: {{ rubyMessageType . }}).returns(String) }
+  def self.encode_json(msg)
+  end
 {{ if willGenerateInvalidRuby .Fields }}
   # Constants of the form Constant_1 are invalid. We've declined to type this as a result, taking a hash instead.
   sig { params(args: T::Hash[T.untyped, T.untyped]).void }
@@ -134,8 +150,12 @@ class {{ rubyMessageType . }}
 module {{ rubyMessageType . }}{{ range .Values }}
   {{ .Name }} = T.let({{ .Value }}, Integer){{ end }}
 
-  sig { params(value: Integer).returns(Symbol) }
+  sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)
+  end
+
+  sig { params(value: Symbol).returns(T.nilable(Integer)) }
+  def self.resolve(value)
   end
 end
 {{ end }}`

--- a/testdata/example_pb.rbi
+++ b/testdata/example_pb.rbi
@@ -8,6 +8,22 @@ class Example::Request
   include Google::Protobuf
   include Google::Protobuf::MessageExts
 
+  sig { params(str: String).returns(Example::Request) }
+  def self.decode(str)
+  end
+
+  sig { params(msg: Example::Request).returns(String) }
+  def self.encode(msg)
+  end
+
+  sig { params(str: String).returns(Example::Request) }
+  def self.decode_json(str)
+  end
+
+  sig { params(msg: Example::Request).returns(String) }
+  def self.encode_json(msg)
+  end
+
   sig do
     params(
       name: String
@@ -30,6 +46,22 @@ end
 class Example::Response
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+
+  sig { params(str: String).returns(Example::Response) }
+  def self.decode(str)
+  end
+
+  sig { params(msg: Example::Response).returns(String) }
+  def self.encode(msg)
+  end
+
+  sig { params(str: String).returns(Example::Response) }
+  def self.decode_json(str)
+  end
+
+  sig { params(msg: Example::Response).returns(String) }
+  def self.encode_json(msg)
+  end
 
   sig do
     params(

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -9,6 +9,22 @@ class Testdata::Subdir::IntegerMessage
   include Google::Protobuf
   include Google::Protobuf::MessageExts
 
+  sig { params(str: String).returns(Testdata::Subdir::IntegerMessage) }
+  def self.decode(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::IntegerMessage).returns(String) }
+  def self.encode(msg)
+  end
+
+  sig { params(str: String).returns(Testdata::Subdir::IntegerMessage) }
+  def self.decode_json(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::IntegerMessage).returns(String) }
+  def self.encode_json(msg)
+  end
+
   sig do
     params(
       value: Integer
@@ -31,11 +47,43 @@ end
 class Testdata::Subdir::Empty
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+
+  sig { params(str: String).returns(Testdata::Subdir::Empty) }
+  def self.decode(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::Empty).returns(String) }
+  def self.encode(msg)
+  end
+
+  sig { params(str: String).returns(Testdata::Subdir::Empty) }
+  def self.decode_json(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::Empty).returns(String) }
+  def self.encode_json(msg)
+  end
 end
 
 class Testdata::Subdir::AllTypes
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+
+  sig { params(str: String).returns(Testdata::Subdir::AllTypes) }
+  def self.decode(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::AllTypes).returns(String) }
+  def self.encode(msg)
+  end
+
+  sig { params(str: String).returns(Testdata::Subdir::AllTypes) }
+  def self.decode_json(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::AllTypes).returns(String) }
+  def self.encode_json(msg)
+  end
 
   sig do
     params(
@@ -330,6 +378,22 @@ class Testdata::Subdir::IntegerMessage::InnerNestedMessage
   include Google::Protobuf
   include Google::Protobuf::MessageExts
 
+  sig { params(str: String).returns(Testdata::Subdir::IntegerMessage::InnerNestedMessage) }
+  def self.decode(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::IntegerMessage::InnerNestedMessage).returns(String) }
+  def self.encode(msg)
+  end
+
+  sig { params(str: String).returns(Testdata::Subdir::IntegerMessage::InnerNestedMessage) }
+  def self.decode_json(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::IntegerMessage::InnerNestedMessage).returns(String) }
+  def self.encode_json(msg)
+  end
+
   sig do
     params(
       value: Float
@@ -352,11 +416,43 @@ end
 class Testdata::Subdir::IntegerMessage::NestedEmpty
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+
+  sig { params(str: String).returns(Testdata::Subdir::IntegerMessage::NestedEmpty) }
+  def self.decode(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::IntegerMessage::NestedEmpty).returns(String) }
+  def self.encode(msg)
+  end
+
+  sig { params(str: String).returns(Testdata::Subdir::IntegerMessage::NestedEmpty) }
+  def self.decode_json(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::IntegerMessage::NestedEmpty).returns(String) }
+  def self.encode_json(msg)
+  end
 end
 
 class Testdata::Subdir::AllTypes::InnerMessage
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+
+  sig { params(str: String).returns(Testdata::Subdir::AllTypes::InnerMessage) }
+  def self.decode(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::AllTypes::InnerMessage).returns(String) }
+  def self.encode(msg)
+  end
+
+  sig { params(str: String).returns(Testdata::Subdir::AllTypes::InnerMessage) }
+  def self.decode_json(str)
+  end
+
+  sig { params(msg: Testdata::Subdir::AllTypes::InnerMessage).returns(String) }
+  def self.encode_json(msg)
+  end
 
   sig do
     params(
@@ -386,8 +482,12 @@ module Testdata::Subdir::AllTypes::Corpus
   PRODUCTS = T.let(5, Integer)
   VIDEO = T.let(6, Integer)
 
-  sig { params(value: Integer).returns(Symbol) }
+  sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)
+  end
+
+  sig { params(value: Symbol).returns(T.nilable(Integer)) }
+  def self.resolve(value)
   end
 end
 
@@ -396,7 +496,11 @@ module Testdata::Subdir::AllTypes::EnumAllowingAlias
   STARTED = T.let(1, Integer)
   RUNNING = T.let(1, Integer)
 
-  sig { params(value: Integer).returns(Symbol) }
+  sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)
+  end
+
+  sig { params(value: Symbol).returns(T.nilable(Integer)) }
+  def self.resolve(value)
   end
 end


### PR DESCRIPTION
The currently generated RBI files are missing a few methods that are documented in the [Ruby docs for protobuf](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated). 

These include a method on Enum to resolve a symbol to an integer and the class methods that encode or decode a message as a String or JSON.

I've updated the tests to reflect these.

cc @praboud-stripe