### PR TITLE
Add missing to_h method

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,11 +123,6 @@ class {{ rubyMessageType . }}
   sig { params(msg: {{ rubyMessageType . }}).returns(String) }
   def self.encode_json(msg)
   end
-
-  sig { returns(T::Hash[Symbol, T.untyped]) }
-  def to_h
-  end
-
 {{ if willGenerateInvalidRuby .Fields }}
   # Constants of the form Constant_1 are invalid. We've declined to type this as a result, taking a hash instead.
   sig { params(args: T::Hash[T.untyped, T.untyped]).void }
@@ -150,7 +145,11 @@ class {{ rubyMessageType . }}
   sig { params(value: {{ rubySetterFieldType . }}).void }
   def {{ .Name }}=(value)
   end
-{{ end }}end
+{{ end }}
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+end
 {{ end }}{{ range .AllEnums }}
 module {{ rubyMessageType . }}{{ range .Values }}
   {{ .Name }} = T.let({{ .Value }}, Integer){{ end }}

--- a/main.go
+++ b/main.go
@@ -123,6 +123,11 @@ class {{ rubyMessageType . }}
   sig { params(msg: {{ rubyMessageType . }}).returns(String) }
   def self.encode_json(msg)
   end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
 {{ if willGenerateInvalidRuby .Fields }}
   # Constants of the form Constant_1 are invalid. We've declined to type this as a result, taking a hash instead.
   sig { params(args: T::Hash[T.untyped, T.untyped]).void }

--- a/testdata/broken_field_name_pb.rbi
+++ b/testdata/broken_field_name_pb.rbi
@@ -24,6 +24,11 @@ class Example::Broken_field_name
   def self.encode_json(msg)
   end
 
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
+
   # Constants of the form Constant_1 are invalid. We've declined to type this as a result, taking a hash instead.
   sig { params(args: T::Hash[T.untyped, T.untyped]).void }
   def initialize(args); end

--- a/testdata/broken_field_name_pb.rbi
+++ b/testdata/broken_field_name_pb.rbi
@@ -24,11 +24,6 @@ class Example::Broken_field_name
   def self.encode_json(msg)
   end
 
-  sig { returns(T::Hash[Symbol, T.untyped]) }
-  def to_h
-  end
-
-
   # Constants of the form Constant_1 are invalid. We've declined to type this as a result, taking a hash instead.
   sig { params(args: T::Hash[T.untyped, T.untyped]).void }
   def initialize(args); end
@@ -47,5 +42,9 @@ class Example::Broken_field_name
 
   sig { params(value: String).void }
   def Field_name_1=(value)
+  end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
   end
 end

--- a/testdata/example_pb.rbi
+++ b/testdata/example_pb.rbi
@@ -24,11 +24,6 @@ class Example::Request
   def self.encode_json(msg)
   end
 
-  sig { returns(T::Hash[Symbol, T.untyped]) }
-  def to_h
-  end
-
-
   sig do
     params(
       name: String
@@ -45,6 +40,10 @@ class Example::Request
 
   sig { params(value: String).void }
   def name=(value)
+  end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
   end
 end
 
@@ -68,11 +67,6 @@ class Example::Response
   def self.encode_json(msg)
   end
 
-  sig { returns(T::Hash[Symbol, T.untyped]) }
-  def to_h
-  end
-
-
   sig do
     params(
       greeting: String
@@ -89,5 +83,9 @@ class Example::Response
 
   sig { params(value: String).void }
   def greeting=(value)
+  end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
   end
 end

--- a/testdata/example_pb.rbi
+++ b/testdata/example_pb.rbi
@@ -24,6 +24,11 @@ class Example::Request
   def self.encode_json(msg)
   end
 
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
+
   sig do
     params(
       name: String
@@ -62,6 +67,11 @@ class Example::Response
   sig { params(msg: Example::Response).returns(String) }
   def self.encode_json(msg)
   end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
 
   sig do
     params(

--- a/testdata/lowercase_pb.rbi
+++ b/testdata/lowercase_pb.rbi
@@ -24,11 +24,6 @@ class Example::Lowercase
   def self.encode_json(msg)
   end
 
-  sig { returns(T::Hash[Symbol, T.untyped]) }
-  def to_h
-  end
-
-
   sig do
     params(
       example_proto_field: String
@@ -45,6 +40,10 @@ class Example::Lowercase
 
   sig { params(value: String).void }
   def example_proto_field=(value)
+  end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
   end
 end
 
@@ -68,11 +67,6 @@ class Example::Lowercase_with_underscores
   def self.encode_json(msg)
   end
 
-  sig { returns(T::Hash[Symbol, T.untyped]) }
-  def to_h
-  end
-
-
   sig do
     params(
       example_proto_field: String
@@ -89,5 +83,9 @@ class Example::Lowercase_with_underscores
 
   sig { params(value: String).void }
   def example_proto_field=(value)
+  end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
   end
 end

--- a/testdata/lowercase_pb.rbi
+++ b/testdata/lowercase_pb.rbi
@@ -24,6 +24,11 @@ class Example::Lowercase
   def self.encode_json(msg)
   end
 
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
+
   sig do
     params(
       example_proto_field: String
@@ -62,6 +67,11 @@ class Example::Lowercase_with_underscores
   sig { params(msg: Example::Lowercase_with_underscores).returns(String) }
   def self.encode_json(msg)
   end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
 
   sig do
     params(

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -25,11 +25,6 @@ class Testdata::Subdir::IntegerMessage
   def self.encode_json(msg)
   end
 
-  sig { returns(T::Hash[Symbol, T.untyped]) }
-  def to_h
-  end
-
-
   sig do
     params(
       value: Integer
@@ -46,6 +41,10 @@ class Testdata::Subdir::IntegerMessage
 
   sig { params(value: Integer).void }
   def value=(value)
+  end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
   end
 end
 
@@ -72,7 +71,6 @@ class Testdata::Subdir::Empty
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
   end
-
 end
 
 class Testdata::Subdir::AllTypes
@@ -94,11 +92,6 @@ class Testdata::Subdir::AllTypes
   sig { params(msg: Testdata::Subdir::AllTypes).returns(String) }
   def self.encode_json(msg)
   end
-
-  sig { returns(T::Hash[Symbol, T.untyped]) }
-  def to_h
-  end
-
 
   sig do
     params(
@@ -387,6 +380,10 @@ class Testdata::Subdir::AllTypes
   sig { params(value: Google::Protobuf::Map).void }
   def enum_map_value=(value)
   end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
 end
 
 class Testdata::Subdir::IntegerMessage::InnerNestedMessage
@@ -409,11 +406,6 @@ class Testdata::Subdir::IntegerMessage::InnerNestedMessage
   def self.encode_json(msg)
   end
 
-  sig { returns(T::Hash[Symbol, T.untyped]) }
-  def to_h
-  end
-
-
   sig do
     params(
       value: Float
@@ -430,6 +422,10 @@ class Testdata::Subdir::IntegerMessage::InnerNestedMessage
 
   sig { params(value: Float).void }
   def value=(value)
+  end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
   end
 end
 
@@ -456,7 +452,6 @@ class Testdata::Subdir::IntegerMessage::NestedEmpty
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
   end
-
 end
 
 class Testdata::Subdir::AllTypes::InnerMessage
@@ -479,11 +474,6 @@ class Testdata::Subdir::AllTypes::InnerMessage
   def self.encode_json(msg)
   end
 
-  sig { returns(T::Hash[Symbol, T.untyped]) }
-  def to_h
-  end
-
-
   sig do
     params(
       value: String
@@ -500,6 +490,10 @@ class Testdata::Subdir::AllTypes::InnerMessage
 
   sig { params(value: String).void }
   def value=(value)
+  end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
   end
 end
 

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -25,6 +25,11 @@ class Testdata::Subdir::IntegerMessage
   def self.encode_json(msg)
   end
 
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
+
   sig do
     params(
       value: Integer
@@ -63,6 +68,11 @@ class Testdata::Subdir::Empty
   sig { params(msg: Testdata::Subdir::Empty).returns(String) }
   def self.encode_json(msg)
   end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
 end
 
 class Testdata::Subdir::AllTypes
@@ -84,6 +94,11 @@ class Testdata::Subdir::AllTypes
   sig { params(msg: Testdata::Subdir::AllTypes).returns(String) }
   def self.encode_json(msg)
   end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
 
   sig do
     params(
@@ -394,6 +409,11 @@ class Testdata::Subdir::IntegerMessage::InnerNestedMessage
   def self.encode_json(msg)
   end
 
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
+
   sig do
     params(
       value: Float
@@ -432,6 +452,11 @@ class Testdata::Subdir::IntegerMessage::NestedEmpty
   sig { params(msg: Testdata::Subdir::IntegerMessage::NestedEmpty).returns(String) }
   def self.encode_json(msg)
   end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
 end
 
 class Testdata::Subdir::AllTypes::InnerMessage
@@ -453,6 +478,11 @@ class Testdata::Subdir::AllTypes::InnerMessage
   sig { params(msg: Testdata::Subdir::AllTypes::InnerMessage).returns(String) }
   def self.encode_json(msg)
   end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+  end
+
 
   sig do
     params(


### PR DESCRIPTION
Add [Message#to_h](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#message) method to generated RBI files.