### PR TITLE
Use T::Enumerable for Repeated Fields

### DIFF
--- a/ruby_types/ruby_types.go
+++ b/ruby_types/ruby_types.go
@@ -87,7 +87,7 @@ func rubyFieldType(field pgs.Field, mt methodType) string {
 		return fmt.Sprintf("T::Hash[%s, %s]", key, value)
 	} else if t.IsRepeated() {
 		value := rubyProtoTypeElem(field, t.Element(), mt)
-		return fmt.Sprintf("T::Array[%s]", value)
+		return fmt.Sprintf("T::Enumerable[%s]", value)
 	}
 	return rubyProtoTypeElem(field, t, mt)
 }

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -105,9 +105,9 @@ class Testdata::Subdir::AllTypes
       enum_value: T.any(Symbol, String, Integer),
       alias_enum_value: T.any(Symbol, String, Integer),
       nested_value: T.nilable(Testdata::Subdir::IntegerMessage),
-      repeated_nested_value: T::Array[T.nilable(Testdata::Subdir::IntegerMessage)],
-      repeated_int32_value: T::Array[Integer],
-      repeated_enum: T::Array[T.any(Symbol, String, Integer)],
+      repeated_nested_value: T::Enumerable[T.nilable(Testdata::Subdir::IntegerMessage)],
+      repeated_int32_value: T::Enumerable[Integer],
+      repeated_enum: T::Enumerable[T.any(Symbol, String, Integer)],
       inner_value: T.nilable(Testdata::Subdir::AllTypes::InnerMessage),
       inner_nested_value: T.nilable(Testdata::Subdir::IntegerMessage::InnerNestedMessage),
       name: String,
@@ -293,27 +293,27 @@ class Testdata::Subdir::AllTypes
   def nested_value=(value)
   end
 
-  sig { returns(T::Array[T.nilable(Testdata::Subdir::IntegerMessage)]) }
+  sig { returns(T::Enumerable[T.nilable(Testdata::Subdir::IntegerMessage)]) }
   def repeated_nested_value
   end
 
-  sig { params(value: T::Array[T.nilable(Testdata::Subdir::IntegerMessage)]).void }
+  sig { params(value: T::Enumerable[T.nilable(Testdata::Subdir::IntegerMessage)]).void }
   def repeated_nested_value=(value)
   end
 
-  sig { returns(T::Array[Integer]) }
+  sig { returns(T::Enumerable[Integer]) }
   def repeated_int32_value
   end
 
-  sig { params(value: T::Array[Integer]).void }
+  sig { params(value: T::Enumerable[Integer]).void }
   def repeated_int32_value=(value)
   end
 
-  sig { returns(T::Array[Symbol]) }
+  sig { returns(T::Enumerable[Symbol]) }
   def repeated_enum
   end
 
-  sig { params(value: T::Array[T.any(Symbol, String, Integer)]).void }
+  sig { params(value: T::Enumerable[T.any(Symbol, String, Integer)]).void }
   def repeated_enum=(value)
   end
 


### PR DESCRIPTION
Proto repeated fields are generated with an rbi of return type `T::Array` when the underlying `Google::protobuf::RepeatedField` is not of type array but an enumerable. This causes sorbet run time issues not evident in the static analysis when repeated fields are used in places that expect a `T::Array`.

> Repeated fields are represented using a custom class Google::Protobuf::RepeatedField. This class acts like a Ruby Array and mixes in Enumerable. The RepeatedField type supports all of the same methods as a regular Ruby Array. You can convert it to a regular Ruby Array with repeated_field.to_a.
https://developers.google.com/protocol-buffers/docs/reference/ruby-generated

```
[dev] main:0> Google::Protobuf::RepeatedField.ancestors
=> [Google::Protobuf::RepeatedField, Enumerable, Object, Kernel, BasicObject]
```

The rbi output will use `T::Enumerable`