### PR TITLE
Support kwargs in encode_json/decode_json

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,12 +116,12 @@ class {{ rubyMessageType . }}
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns({{ rubyMessageType . }}) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns({{ rubyMessageType . }}) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: {{ rubyMessageType . }}).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: {{ rubyMessageType . }}, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 {{ if willGenerateInvalidRuby .Fields }}
   # Constants of the form Constant_1 are invalid. We've declined to type this as a result, taking a hash instead.

--- a/testdata/broken_field_name_pb.rbi
+++ b/testdata/broken_field_name_pb.rbi
@@ -16,12 +16,12 @@ class Example::Broken_field_name
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Example::Broken_field_name) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Example::Broken_field_name) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Example::Broken_field_name).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Example::Broken_field_name, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   # Constants of the form Constant_1 are invalid. We've declined to type this as a result, taking a hash instead.

--- a/testdata/example_pb.rbi
+++ b/testdata/example_pb.rbi
@@ -16,12 +16,12 @@ class Example::Request
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Example::Request) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Example::Request) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Example::Request).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Example::Request, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   sig do
@@ -59,12 +59,12 @@ class Example::Response
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Example::Response) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Example::Response) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Example::Response).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Example::Response, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   sig do

--- a/testdata/lowercase_pb.rbi
+++ b/testdata/lowercase_pb.rbi
@@ -16,12 +16,12 @@ class Example::Lowercase
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Example::Lowercase) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Example::Lowercase) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Example::Lowercase).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Example::Lowercase, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   sig do
@@ -59,12 +59,12 @@ class Example::Lowercase_with_underscores
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Example::Lowercase_with_underscores) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Example::Lowercase_with_underscores) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Example::Lowercase_with_underscores).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Example::Lowercase_with_underscores, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   sig do

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -17,12 +17,12 @@ class Testdata::Subdir::IntegerMessage
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Testdata::Subdir::IntegerMessage) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Testdata::Subdir::IntegerMessage) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Testdata::Subdir::IntegerMessage).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Testdata::Subdir::IntegerMessage, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   sig do
@@ -60,12 +60,12 @@ class Testdata::Subdir::Empty
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Testdata::Subdir::Empty) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Testdata::Subdir::Empty) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Testdata::Subdir::Empty).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Testdata::Subdir::Empty, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -85,12 +85,12 @@ class Testdata::Subdir::AllTypes
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Testdata::Subdir::AllTypes) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Testdata::Subdir::AllTypes) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Testdata::Subdir::AllTypes).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Testdata::Subdir::AllTypes, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   sig do
@@ -398,12 +398,12 @@ class Testdata::Subdir::IntegerMessage::InnerNestedMessage
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Testdata::Subdir::IntegerMessage::InnerNestedMessage) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Testdata::Subdir::IntegerMessage::InnerNestedMessage) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Testdata::Subdir::IntegerMessage::InnerNestedMessage).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Testdata::Subdir::IntegerMessage::InnerNestedMessage, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   sig do
@@ -441,12 +441,12 @@ class Testdata::Subdir::IntegerMessage::NestedEmpty
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Testdata::Subdir::IntegerMessage::NestedEmpty) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Testdata::Subdir::IntegerMessage::NestedEmpty) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Testdata::Subdir::IntegerMessage::NestedEmpty).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Testdata::Subdir::IntegerMessage::NestedEmpty, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -466,12 +466,12 @@ class Testdata::Subdir::AllTypes::InnerMessage
   def self.encode(msg)
   end
 
-  sig { params(str: String).returns(Testdata::Subdir::AllTypes::InnerMessage) }
-  def self.decode_json(str)
+  sig { params(str: String, kw: T.untyped).returns(Testdata::Subdir::AllTypes::InnerMessage) }
+  def self.decode_json(str, **kw)
   end
 
-  sig { params(msg: Testdata::Subdir::AllTypes::InnerMessage).returns(String) }
-  def self.encode_json(msg)
+  sig { params(msg: Testdata::Subdir::AllTypes::InnerMessage, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
   end
 
   sig do


### PR DESCRIPTION
Encoding / decoding JSON supports passing options (e.g. `emit_defaults: true` for encoding, or `ignore_unknown_fields: true` for decoding).