### PR TITLE
Use Array for RepeatedField getter and constructor, not for setter

### DIFF
--- a/ruby_types/ruby_types.go
+++ b/ruby_types/ruby_types.go
@@ -108,8 +108,14 @@ func rubyFieldMapType(field pgs.Field, ft pgs.FieldType, mt methodType) string {
 }
 
 func rubyFieldRepeatedType(field pgs.Field, ft pgs.FieldType, mt methodType) string {
+	// An enumerable/array is not accepted at the setter
+	// See: https://github.com/protocolbuffers/protobuf/issues/4969
+	// See: https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#repeated-fields
+	if mt == methodTypeSetter {
+		return "Google::Protobuf::RepeatedField"
+	}
 	value := rubyProtoTypeElem(field, ft.Element(), mt)
-	return fmt.Sprintf("T::Enumerable[%s]", value)
+	return fmt.Sprintf("T::Array[%s]", value)
 }
 
 func RubyFieldValue(field pgs.Field) string {

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -113,9 +113,9 @@ class Testdata::Subdir::AllTypes
       enum_value: T.nilable(T.any(Symbol, String, Integer)),
       alias_enum_value: T.nilable(T.any(Symbol, String, Integer)),
       nested_value: T.nilable(Testdata::Subdir::IntegerMessage),
-      repeated_nested_value: T.nilable(T::Enumerable[T.nilable(Testdata::Subdir::IntegerMessage)]),
-      repeated_int32_value: T.nilable(T::Enumerable[Integer]),
-      repeated_enum: T.nilable(T::Enumerable[T.any(Symbol, String, Integer)]),
+      repeated_nested_value: T.nilable(T::Array[T.nilable(Testdata::Subdir::IntegerMessage)]),
+      repeated_int32_value: T.nilable(T::Array[Integer]),
+      repeated_enum: T.nilable(T::Array[T.any(Symbol, String, Integer)]),
       inner_value: T.nilable(Testdata::Subdir::AllTypes::InnerMessage),
       inner_nested_value: T.nilable(Testdata::Subdir::IntegerMessage::InnerNestedMessage),
       name: T.nilable(String),
@@ -301,27 +301,27 @@ class Testdata::Subdir::AllTypes
   def nested_value=(value)
   end
 
-  sig { returns(T::Enumerable[T.nilable(Testdata::Subdir::IntegerMessage)]) }
+  sig { returns(T::Array[T.nilable(Testdata::Subdir::IntegerMessage)]) }
   def repeated_nested_value
   end
 
-  sig { params(value: T::Enumerable[T.nilable(Testdata::Subdir::IntegerMessage)]).void }
+  sig { params(value: Google::Protobuf::RepeatedField).void }
   def repeated_nested_value=(value)
   end
 
-  sig { returns(T::Enumerable[Integer]) }
+  sig { returns(T::Array[Integer]) }
   def repeated_int32_value
   end
 
-  sig { params(value: T::Enumerable[Integer]).void }
+  sig { params(value: Google::Protobuf::RepeatedField).void }
   def repeated_int32_value=(value)
   end
 
-  sig { returns(T::Enumerable[Symbol]) }
+  sig { returns(T::Array[Symbol]) }
   def repeated_enum
   end
 
-  sig { params(value: T::Enumerable[T.any(Symbol, String, Integer)]).void }
+  sig { params(value: Google::Protobuf::RepeatedField).void }
   def repeated_enum=(value)
   end
 


### PR DESCRIPTION
According to https://github.com/protocolbuffers/protobuf/issues/4969 an
array cannot be used at the setter, it needs to be a repeatedfield.

Using Array instead of Enumerable at constructor and getter allows using
.replace() and += to add elements to a RepeatedField without having to
explicitly using a RepeatedField.new in your code.