### PR TITLE
Add `#[]` and `#[]=` methods to message classes

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,6 +154,14 @@ class {{ rubyMessageType . }}
   def {{ .Name }}
   end
 {{ end }}
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
+  end
+
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
   end

--- a/testdata/broken_field_name_pb.rbi
+++ b/testdata/broken_field_name_pb.rbi
@@ -48,6 +48,14 @@ class Example::Broken_field_name
   def Field_name_1=(value)
   end
 
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
+  end
+
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
   end

--- a/testdata/example_pb.rbi
+++ b/testdata/example_pb.rbi
@@ -46,6 +46,14 @@ class Example::Request
   def name=(value)
   end
 
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
+  end
+
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
   end
@@ -91,6 +99,14 @@ class Example::Response
 
   sig { params(value: String).void }
   def greeting=(value)
+  end
+
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
   end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }

--- a/testdata/lowercase_pb.rbi
+++ b/testdata/lowercase_pb.rbi
@@ -46,6 +46,14 @@ class Example::Lowercase
   def example_proto_field=(value)
   end
 
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
+  end
+
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
   end
@@ -91,6 +99,14 @@ class Example::Lowercase_with_underscores
 
   sig { params(value: String).void }
   def example_proto_field=(value)
+  end
+
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
   end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -47,6 +47,14 @@ class Testdata::Subdir::IntegerMessage
   def value=(value)
   end
 
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
+  end
+
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
   end
@@ -74,6 +82,14 @@ class Testdata::Subdir::Empty
 
   sig { returns(Google::Protobuf::Descriptor) }
   def self.descriptor
+  end
+
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
   end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -397,6 +413,14 @@ class Testdata::Subdir::AllTypes
   def test_oneof
   end
 
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
+  end
+
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
   end
@@ -444,6 +468,14 @@ class Testdata::Subdir::IntegerMessage::InnerNestedMessage
   def value=(value)
   end
 
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
+  end
+
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
   end
@@ -471,6 +503,14 @@ class Testdata::Subdir::IntegerMessage::NestedEmpty
 
   sig { returns(Google::Protobuf::Descriptor) }
   def self.descriptor
+  end
+
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
   end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -518,6 +558,14 @@ class Testdata::Subdir::AllTypes::InnerMessage
 
   sig { params(value: String).void }
   def value=(value)
+  end
+
+  sig { params(field: String).returns(T.untyped) }
+  def [](field)
+  end
+
+  sig { params(field: String, value: T.untyped).void }
+  def []=(field, value)
   end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }


### PR DESCRIPTION
These methods allow dynamically getting or setting any field value. Ideally, we could create a type alias for a big `T.any` instead of using `T.untyped`, but that type would have to be recursive for repeated and map fields, and Sorbet doesn't support that.

See https://github.com/protocolbuffers/protobuf/blob/80fe990b6aef57dd92a3fa2864649cc5643cc0ec/ruby/ext/google/protobuf_c/message.c#L865-L907.