### PR TITLE
Support ruby reserved word enum fields

### DIFF
--- a/main.go
+++ b/main.go
@@ -186,7 +186,7 @@ class {{ rubyMessageType . }}
 end
 {{ end }}{{ range .AllEnums }}
 module {{ rubyMessageType . }}{{ range .Values }}
-  {{ .Name }} = T.let({{ .Value }}, Integer){{ end }}
+  self::{{ .Name }} = T.let({{ .Value }}, Integer){{ end }}
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)

--- a/testdata/subdir/messages.proto
+++ b/testdata/subdir/messages.proto
@@ -41,6 +41,7 @@ message AllTypes {
     NEWS = 4;
     PRODUCTS = 5;
     VIDEO = 6;
+    END = 7;
   }
   Corpus enum_value = 16;
 

--- a/testdata/subdir/messages_pb.rb
+++ b/testdata/subdir/messages_pb.rb
@@ -59,6 +59,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       value :NEWS, 4
       value :PRODUCTS, 5
       value :VIDEO, 6
+      value :END, 7
     end
     add_enum "testdata.subdir.AllTypes.EnumAllowingAlias" do
       value :UNKNOWN, 0

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -716,13 +716,14 @@ class Testdata::Subdir::AllTypes::InnerMessage
 end
 
 module Testdata::Subdir::AllTypes::Corpus
-  UNIVERSAL = T.let(0, Integer)
-  WEB = T.let(1, Integer)
-  IMAGES = T.let(2, Integer)
-  LOCAL = T.let(3, Integer)
-  NEWS = T.let(4, Integer)
-  PRODUCTS = T.let(5, Integer)
-  VIDEO = T.let(6, Integer)
+  self::UNIVERSAL = T.let(0, Integer)
+  self::WEB = T.let(1, Integer)
+  self::IMAGES = T.let(2, Integer)
+  self::LOCAL = T.let(3, Integer)
+  self::NEWS = T.let(4, Integer)
+  self::PRODUCTS = T.let(5, Integer)
+  self::VIDEO = T.let(6, Integer)
+  self::END = T.let(7, Integer)
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)
@@ -734,9 +735,9 @@ module Testdata::Subdir::AllTypes::Corpus
 end
 
 module Testdata::Subdir::AllTypes::EnumAllowingAlias
-  UNKNOWN = T.let(0, Integer)
-  STARTED = T.let(1, Integer)
-  RUNNING = T.let(1, Integer)
+  self::UNKNOWN = T.let(0, Integer)
+  self::STARTED = T.let(1, Integer)
+  self::RUNNING = T.let(1, Integer)
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)


### PR DESCRIPTION
We currently generate invalid RBI files if an enum in a proto is named after a reserved word in ruby, namely `BEGIN` or `END`.

We can avoid this by prepending `self::` to our constant definitions in the RBI file (ht: @jez-stripe)

`END = T.let(7, Integer)` is an error `self::END = T.let(7, Integer)` is fine.