### PR TITLE
Also extend ClassMethods

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ module {{ . }}; end{{ end }}
 class {{ rubyMessageType . }}
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns({{ rubyMessageType . }}) }
   def self.decode(str)

--- a/testdata/broken_field_name_pb.rbi
+++ b/testdata/broken_field_name_pb.rbi
@@ -7,6 +7,7 @@ module Example; end
 class Example::Broken_field_name
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Example::Broken_field_name) }
   def self.decode(str)

--- a/testdata/broken_package_name_pb.rbi
+++ b/testdata/broken_package_name_pb.rbi
@@ -7,6 +7,7 @@ module Package2test; end
 class Package2test::Message2test
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Package2test::Message2test) }
   def self.decode(str)

--- a/testdata/example_pb.rbi
+++ b/testdata/example_pb.rbi
@@ -7,6 +7,7 @@ module Example; end
 class Example::Request
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Example::Request) }
   def self.decode(str)
@@ -66,6 +67,7 @@ end
 class Example::Response
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Example::Response) }
   def self.decode(str)

--- a/testdata/lowercase_pb.rbi
+++ b/testdata/lowercase_pb.rbi
@@ -7,6 +7,7 @@ module Example; end
 class Example::Lowercase
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Example::Lowercase) }
   def self.decode(str)
@@ -66,6 +67,7 @@ end
 class Example::Lowercase_with_underscores
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Example::Lowercase_with_underscores) }
   def self.decode(str)

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -8,6 +8,7 @@ module Testdata::Subdir; end
 class Testdata::Subdir::IntegerMessage
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Testdata::Subdir::IntegerMessage) }
   def self.decode(str)
@@ -67,6 +68,7 @@ end
 class Testdata::Subdir::Empty
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Testdata::Subdir::Empty) }
   def self.decode(str)
@@ -104,6 +106,7 @@ end
 class Testdata::Subdir::AllTypes
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Testdata::Subdir::AllTypes) }
   def self.decode(str)
@@ -563,6 +566,7 @@ end
 class Testdata::Subdir::IntegerMessage::InnerNestedMessage
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Testdata::Subdir::IntegerMessage::InnerNestedMessage) }
   def self.decode(str)
@@ -622,6 +626,7 @@ end
 class Testdata::Subdir::IntegerMessage::NestedEmpty
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Testdata::Subdir::IntegerMessage::NestedEmpty) }
   def self.decode(str)
@@ -659,6 +664,7 @@ end
 class Testdata::Subdir::AllTypes::InnerMessage
   include Google::Protobuf
   include Google::Protobuf::MessageExts
+  extend Google::Protobuf::MessageExts::ClassMethods
 
   sig { params(str: String).returns(Testdata::Subdir::AllTypes::InnerMessage) }
   def self.decode(str)


### PR DESCRIPTION
This is what will actually happen at runtime, as seen here:

<https://github.com/protocolbuffers/protobuf/blob/7ccf4d8f67878a6ceb2184df279478cb3314372b/ruby/ext/google/protobuf_c/message.c#L1131-L1133>

And when we use reflection (e.g., `srb rbi hidden-definitions`) to discover
things that are missing statically, we see many, many lines that look like
this in the generated RBIs. This should cut down on a lot of that.