### PR TITLE
Generate initialize with no arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,6 +152,9 @@ class {{ rubyMessageType . }}
     {{ .Name }}: {{ rubyFieldValue . }}{{ end }}
   )
   end
+{{ else }}
+  sig {void}
+  def initialize; end
 {{ end }}{{ range .Fields }}
   sig { returns({{ rubyGetterFieldType . }}) }
   def {{ .Name }}

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -90,6 +90,9 @@ class Testdata::Subdir::Empty
   def self.descriptor
   end
 
+  sig {void}
+  def initialize; end
+
   sig { params(field: String).returns(T.untyped) }
   def [](field)
   end
@@ -647,6 +650,9 @@ class Testdata::Subdir::IntegerMessage::NestedEmpty
   sig { returns(Google::Protobuf::Descriptor) }
   def self.descriptor
   end
+
+  sig {void}
+  def initialize; end
 
   sig { params(field: String).returns(T.untyped) }
   def [](field)


### PR DESCRIPTION
Some messages don't have arguments yet. The method exists at runtime, but
(like all methods defined by Ruby native extensions) it has arity
`def initialize(*args)`.

In addition to `protoc-gen-rbi`, we use a script to generate RBIs using
runtime reflection, which discovers that such an `initialize` method exists
at runtime but is unknown to Sorbet, so that RBI gets created.

Later, fields are added to a proto message, the `protoc-gen-rbi` logic kicks
in and defines something like

```ruby def initialize(
my_field:
) end
```

which is incompatible with the thing in the reflection-generated RBI:

```ruby def initialize(*args); end
```

and so the poor Ruby developer has to run a very long script to regenerate
the runtime reflection-generated RBI.

This PR changes that, so that it's not actually required.