### PR TITLE
Change type to declare that enum getters can be `Integer`

### DIFF
--- a/ruby_types/ruby_types.go
+++ b/ruby_types/ruby_types.go
@@ -140,7 +140,7 @@ func rubyProtoTypeElem(field pgs.Field, ft FieldType, mt methodType) string {
 	}
 	if pt == pgs.EnumT {
 		if mt == methodTypeGetter {
-			return "Symbol"
+			return "T.any(Symbol, Integer)"
 		}
 		return "T.any(Symbol, String, Integer)"
 	}

--- a/testdata/services_pb.rb
+++ b/testdata/services_pb.rb
@@ -4,6 +4,7 @@
 require 'google/protobuf'
 
 require 'subdir/messages_pb'
+
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_file("services.proto", :syntax => :proto3) do
   end

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -374,7 +374,7 @@ class Testdata::Subdir::AllTypes
   def clear_bytes_value
   end
 
-  sig { returns(Symbol) }
+  sig { returns(T.any(Symbol, Integer)) }
   def enum_value
   end
 
@@ -386,7 +386,7 @@ class Testdata::Subdir::AllTypes
   def clear_enum_value
   end
 
-  sig { returns(Symbol) }
+  sig { returns(T.any(Symbol, Integer)) }
   def alias_enum_value
   end
 
@@ -434,7 +434,7 @@ class Testdata::Subdir::AllTypes
   def clear_repeated_int32_value
   end
 
-  sig { returns(T::Array[Symbol]) }
+  sig { returns(T::Array[T.any(Symbol, Integer)]) }
   def repeated_enum
   end
 
@@ -518,7 +518,7 @@ class Testdata::Subdir::AllTypes
   def clear_int32_map_value
   end
 
-  sig { returns(T::Hash[String, Symbol]) }
+  sig { returns(T::Hash[String, T.any(Symbol, Integer)]) }
   def enum_map_value
   end
 


### PR DESCRIPTION
Looks like this type was wrong. From the docs:

> You may assign either a number or a symbol to an enum field. When
> reading the value back, it will be a symbol if the enum value is known,
> or a number if it is unknown.

<https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#enum>