### PR TITLE
Change type to declare that enum getters can be `Integer`

### DIFF
--- a/ruby_types/ruby_types.go
+++ b/ruby_types/ruby_types.go
@@ -152,7 +152,7 @@ func rubyProtoTypeElem(field pgs.Field, ft FieldType, mt methodType) string {
 	}
 	if pt == pgs.EnumT {
 		if mt == methodTypeGetter {
-			return "Symbol"
+			return "T.any(Symbol, Integer)"
 		}
 		return "T.any(Symbol, String, Integer)"
 	}

--- a/testdata/all/subdir/messages_pb.rbi
+++ b/testdata/all/subdir/messages_pb.rbi
@@ -278,7 +278,7 @@ class Testdata::Subdir::AllTypes < ::Google::Protobuf::AbstractMessage
   def clear_bytes_value
   end
 
-  sig { returns(Symbol) }
+  sig { returns(T.any(Symbol, Integer)) }
   def enum_value
   end
 
@@ -290,7 +290,7 @@ class Testdata::Subdir::AllTypes < ::Google::Protobuf::AbstractMessage
   def clear_enum_value
   end
 
-  sig { returns(Symbol) }
+  sig { returns(T.any(Symbol, Integer)) }
   def alias_enum_value
   end
 
@@ -338,7 +338,7 @@ class Testdata::Subdir::AllTypes < ::Google::Protobuf::AbstractMessage
   def clear_repeated_int32_value
   end
 
-  sig { returns(T::Array[Symbol]) }
+  sig { returns(T::Array[T.any(Symbol, Integer)]) }
   def repeated_enum
   end
 
@@ -422,7 +422,7 @@ class Testdata::Subdir::AllTypes < ::Google::Protobuf::AbstractMessage
   def clear_int32_map_value
   end
 
-  sig { returns(T::Hash[String, Symbol]) }
+  sig { returns(T::Hash[String, T.any(Symbol, Integer)]) }
   def enum_map_value
   end
 

--- a/testdata/hide_common_methods/subdir/messages_pb.rbi
+++ b/testdata/hide_common_methods/subdir/messages_pb.rbi
@@ -287,7 +287,7 @@ class Testdata::Subdir::AllTypes
   def clear_bytes_value
   end
 
-  sig { returns(Symbol) }
+  sig { returns(T.any(Symbol, Integer)) }
   def enum_value
   end
 
@@ -299,7 +299,7 @@ class Testdata::Subdir::AllTypes
   def clear_enum_value
   end
 
-  sig { returns(Symbol) }
+  sig { returns(T.any(Symbol, Integer)) }
   def alias_enum_value
   end
 
@@ -347,7 +347,7 @@ class Testdata::Subdir::AllTypes
   def clear_repeated_int32_value
   end
 
-  sig { returns(T::Array[Symbol]) }
+  sig { returns(T::Array[T.any(Symbol, Integer)]) }
   def repeated_enum
   end
 
@@ -431,7 +431,7 @@ class Testdata::Subdir::AllTypes
   def clear_int32_map_value
   end
 
-  sig { returns(T::Hash[String, Symbol]) }
+  sig { returns(T::Hash[String, T.any(Symbol, Integer)]) }
   def enum_map_value
   end
 

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -371,7 +371,7 @@ class Testdata::Subdir::AllTypes
   def clear_bytes_value
   end
 
-  sig { returns(Symbol) }
+  sig { returns(T.any(Symbol, Integer)) }
   def enum_value
   end
 
@@ -383,7 +383,7 @@ class Testdata::Subdir::AllTypes
   def clear_enum_value
   end
 
-  sig { returns(Symbol) }
+  sig { returns(T.any(Symbol, Integer)) }
   def alias_enum_value
   end
 
@@ -431,7 +431,7 @@ class Testdata::Subdir::AllTypes
   def clear_repeated_int32_value
   end
 
-  sig { returns(T::Array[Symbol]) }
+  sig { returns(T::Array[T.any(Symbol, Integer)]) }
   def repeated_enum
   end
 
@@ -515,7 +515,7 @@ class Testdata::Subdir::AllTypes
   def clear_int32_map_value
   end
 
-  sig { returns(T::Hash[String, Symbol]) }
+  sig { returns(T::Hash[String, T.any(Symbol, Integer)]) }
   def enum_map_value
   end
 

--- a/testdata/use_abstract_message/subdir/messages_pb.rbi
+++ b/testdata/use_abstract_message/subdir/messages_pb.rbi
@@ -362,7 +362,7 @@ class Testdata::Subdir::AllTypes < ::Google::Protobuf::AbstractMessage
   def clear_bytes_value
   end
 
-  sig { returns(Symbol) }
+  sig { returns(T.any(Symbol, Integer)) }
   def enum_value
   end
 
@@ -374,7 +374,7 @@ class Testdata::Subdir::AllTypes < ::Google::Protobuf::AbstractMessage
   def clear_enum_value
   end
 
-  sig { returns(Symbol) }
+  sig { returns(T.any(Symbol, Integer)) }
   def alias_enum_value
   end
 
@@ -422,7 +422,7 @@ class Testdata::Subdir::AllTypes < ::Google::Protobuf::AbstractMessage
   def clear_repeated_int32_value
   end
 
-  sig { returns(T::Array[Symbol]) }
+  sig { returns(T::Array[T.any(Symbol, Integer)]) }
   def repeated_enum
   end
 
@@ -506,7 +506,7 @@ class Testdata::Subdir::AllTypes < ::Google::Protobuf::AbstractMessage
   def clear_int32_map_value
   end
 
-  sig { returns(T::Hash[String, Symbol]) }
+  sig { returns(T::Hash[String, T.any(Symbol, Integer)]) }
   def enum_map_value
   end
 


### PR DESCRIPTION
This is reopening #39. A number of colleagues have asked about this in the past month so I figure it's more pressing to fix this now.

- - - - -

Looks like this type was wrong. From the docs:

> You may assign either a number or a symbol to an enum field. When
> reading the value back, it will be a symbol if the enum value is known,
> or a number if it is unknown.

<https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#enum>