### PR TITLE
Regenerate test fixtures, to make master pass

### DIFF
--- a/testbinary/example_bin_pb.rbi
+++ b/testbinary/example_bin_pb.rbi
@@ -65,26 +65,6 @@ class Example::Response
   include ::Google::Protobuf::MessageExts
   extend ::Google::Protobuf::MessageExts::ClassMethods
 
-  sig { params(str: String).returns(Example::Response) }
-  def self.decode(str)
-  end
-
-  sig { params(msg: Example::Response).returns(String) }
-  def self.encode(msg)
-  end
-
-  sig { params(str: String, kw: T.untyped).returns(Example::Response) }
-  def self.decode_json(str, **kw)
-  end
-
-  sig { params(msg: Example::Response, kw: T.untyped).returns(String) }
-  def self.encode_json(msg, **kw)
-  end
-
-  sig { returns(::Google::Protobuf::Descriptor) }
-  def self.descriptor
-  end
-
   sig do
     params(
       greeting: T.nilable(String)
@@ -117,5 +97,25 @@ class Example::Response
 
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
+  end
+
+  sig { params(str: String).returns(Example::Response) }
+  def self.decode(str)
+  end
+
+  sig { params(msg: Example::Response).returns(String) }
+  def self.encode(msg)
+  end
+
+  sig { params(str: String, kw: T.untyped).returns(Example::Response) }
+  def self.decode_json(str, **kw)
+  end
+
+  sig { params(msg: Example::Response, kw: T.untyped).returns(String) }
+  def self.encode_json(msg, **kw)
+  end
+
+  sig { returns(::Google::Protobuf::Descriptor) }
+  def self.descriptor
   end
 end

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -5,6 +5,7 @@
 class Testdata::Subdir::IntegerMessage
   include ::Google::Protobuf::MessageExts
   extend ::Google::Protobuf::MessageExts::ClassMethods
+
   sig do
     params(
       value: T.nilable(Integer)
@@ -38,7 +39,6 @@ class Testdata::Subdir::IntegerMessage
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_h
   end
-
 
   sig { params(str: String).returns(Testdata::Subdir::IntegerMessage) }
   def self.decode(str)


### PR DESCRIPTION
I noticed that `make test` no longer passes on head of master. It looks like https://github.com/coinbase/protoc-gen-rbi/pull/56 caused a diff -- checking out the master commit immediately prior to it results in zero diff again.

This just checks in the result of running `make test`, which gets us back to a passing master.