### PR TITLE
Capitalize Ruby enum value names, to align with protoc

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func (m *rbiModule) InitContext(c pgs.BuildContext) {
 		"rubyMethodTypeComment":    ruby_types.RubyMethodTypeComment,
 		"rubyMethodParamType":      ruby_types.RubyMethodParamType,
 		"rubyMethodReturnType":     ruby_types.RubyMethodReturnType,
+		"rubyEnumValueName":        ruby_types.RubyEnumValueName,
 		"hideCommonMethods":        m.HideCommonMethods,
 		"useAbstractMessage":       m.UseAbstractMessage,
 	}
@@ -222,7 +223,7 @@ class {{ rubyMessageType . }}{{ if useAbstractMessage }} < ::Google::Protobuf::A
 {{ end }}end
 {{ end }}{{ range .AllEnums }}
 module {{ rubyMessageType . }}{{ range .Values }}
-  self::{{ .Name }} = T.let({{ .Value }}, Integer){{ end }}
+  self::{{ rubyEnumValueName .Name }} = T.let({{ .Value }}, Integer){{ end }}
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)

--- a/ruby_types/ruby_types.go
+++ b/ruby_types/ruby_types.go
@@ -266,3 +266,7 @@ func rubyMethodType(message pgs.Message, streaming bool) string {
 	}
 	return t
 }
+
+func RubyEnumValueName(name pgs.Name) string {
+	return strings.Title(string(name))
+}

--- a/testdata/all/subdir/messages_pb.rbi
+++ b/testdata/all/subdir/messages_pb.rbi
@@ -517,7 +517,7 @@ module Testdata::Subdir::AllTypes::Corpus
   self::PRODUCTS = T.let(5, Integer)
   self::VIDEO = T.let(6, Integer)
   self::END = T.let(7, Integer)
-  self::lower = T.let(8, Integer)
+  self::Lower = T.let(8, Integer)
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)

--- a/testdata/all/subdir/messages_pb.rbi
+++ b/testdata/all/subdir/messages_pb.rbi
@@ -517,6 +517,7 @@ module Testdata::Subdir::AllTypes::Corpus
   self::PRODUCTS = T.let(5, Integer)
   self::VIDEO = T.let(6, Integer)
   self::END = T.let(7, Integer)
+  self::lower = T.let(8, Integer)
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)

--- a/testdata/hide_common_methods/subdir/messages_pb.rbi
+++ b/testdata/hide_common_methods/subdir/messages_pb.rbi
@@ -535,6 +535,7 @@ module Testdata::Subdir::AllTypes::Corpus
   self::PRODUCTS = T.let(5, Integer)
   self::VIDEO = T.let(6, Integer)
   self::END = T.let(7, Integer)
+  self::lower = T.let(8, Integer)
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)

--- a/testdata/hide_common_methods/subdir/messages_pb.rbi
+++ b/testdata/hide_common_methods/subdir/messages_pb.rbi
@@ -535,7 +535,7 @@ module Testdata::Subdir::AllTypes::Corpus
   self::PRODUCTS = T.let(5, Integer)
   self::VIDEO = T.let(6, Integer)
   self::END = T.let(7, Integer)
-  self::lower = T.let(8, Integer)
+  self::Lower = T.let(8, Integer)
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)

--- a/testdata/subdir/messages.proto
+++ b/testdata/subdir/messages.proto
@@ -42,6 +42,7 @@ message AllTypes {
     PRODUCTS = 5;
     VIDEO = 6;
     END = 7;
+    lower = 8;
   }
   Corpus enum_value = 16;
 

--- a/testdata/subdir/messages_pb.rb
+++ b/testdata/subdir/messages_pb.rb
@@ -60,6 +60,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       value :PRODUCTS, 5
       value :VIDEO, 6
       value :END, 7
+      value :lower, 8
     end
     add_enum "testdata.subdir.AllTypes.EnumAllowingAlias" do
       value :UNKNOWN, 0

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -727,6 +727,7 @@ module Testdata::Subdir::AllTypes::Corpus
   self::PRODUCTS = T.let(5, Integer)
   self::VIDEO = T.let(6, Integer)
   self::END = T.let(7, Integer)
+  self::lower = T.let(8, Integer)
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)

--- a/testdata/subdir/messages_pb.rbi
+++ b/testdata/subdir/messages_pb.rbi
@@ -727,7 +727,7 @@ module Testdata::Subdir::AllTypes::Corpus
   self::PRODUCTS = T.let(5, Integer)
   self::VIDEO = T.let(6, Integer)
   self::END = T.let(7, Integer)
-  self::lower = T.let(8, Integer)
+  self::Lower = T.let(8, Integer)
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)

--- a/testdata/use_abstract_message/subdir/messages_pb.rbi
+++ b/testdata/use_abstract_message/subdir/messages_pb.rbi
@@ -709,6 +709,7 @@ module Testdata::Subdir::AllTypes::Corpus
   self::PRODUCTS = T.let(5, Integer)
   self::VIDEO = T.let(6, Integer)
   self::END = T.let(7, Integer)
+  self::lower = T.let(8, Integer)
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)

--- a/testdata/use_abstract_message/subdir/messages_pb.rbi
+++ b/testdata/use_abstract_message/subdir/messages_pb.rbi
@@ -709,7 +709,7 @@ module Testdata::Subdir::AllTypes::Corpus
   self::PRODUCTS = T.let(5, Integer)
   self::VIDEO = T.let(6, Integer)
   self::END = T.let(7, Integer)
-  self::lower = T.let(8, Integer)
+  self::Lower = T.let(8, Integer)
 
   sig { params(value: Integer).returns(T.nilable(Symbol)) }
   def self.lookup(value)


### PR DESCRIPTION
We recently discovered that the behavior of protoc and protoc-gen-rbi differ slightly. If you define an enum with lowercased value names, like:

```proto
enum MyEnum {
  my_value = 0;
}
```

Then protoc will secretly capitalize the generated Ruby enum value, so you should reference it like:

```ruby
MyEnum::My_value
```

But `protoc-gen-rbi` will (understandably) _not_ capitalize the values, resulting in an rbi that looks like:

```ruby
module MyEnum
  self::my_value = T.let(0, Integer)
end
```

This discrepancy means that, if you have one of these protos, you can write valid Ruby code that nonetheless your typing tools that use the generated rbi (like Sorbet) will yell at you about, telling you that `MyEnum::My_value` doesn't exist, when it does.

To fix this, I just call `strings.Title` on Ruby enum values; I've also set up tests and verified that they reproduce the problem before the fix, and cease to fail with this fix.

In addition, I verified that this doesn't cause a new risk of collisions -- if you have an enum with multiple values that differ only in case, `protoc` itself blows up, telling you it's invalid:

```
Enum name Test_fix has the same name as test_fix if you ignore case and strip out the enum name prefix (if any). This is error-prone and can lead to undefined behavior. Please avoid doing this. If you are using allow_alias, please assign the same numeric value to both enums. 
```